### PR TITLE
Docker image and workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,22 @@
+name: Build and Test Docker Image
+
+on:
+  push:
+    branches:
+      - docker  # Adjust this to your branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t troute -f docker/Dockerfile.troute .
+
+      - name: Run LowerColorado Test
+        continue-on-error: true  # Continue with the next steps even if this step fails
+        run: docker/troute.sh -V3 -f test/LowerColorado_TX/test_AnA.yaml
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,9 @@
 name: Build and Test Docker Image
 
 on:
-  push:
+  pull_request:
     branches:
-      - docker  # Adjust this to your branch
-
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/docker/Dockerfile.troute
+++ b/docker/Dockerfile.troute
@@ -1,0 +1,33 @@
+FROM rockylinux:9.2 as rocky-base
+RUN yum install -y epel-release 
+RUN yum install -y netcdf netcdf-fortran netcdf-fortran-devel netcdf-openmpi
+
+RUN yum install -y git cmake python python-devel pip 
+# RUN git clone https://github.com/NOAA-OWP/t-route.git
+RUN git clone https://github.com/joshcu/t-route/
+WORKDIR "/t-route/"
+RUN git reset --hard 15bd543
+# 15bd543 <-- after LowerColorado Test fix
+# 2a2f936 <-- no-e compile fix
+
+
+
+RUN ln -s /usr/lib64/gfortran/modules/netcdf.mod /usr/include/openmpi-x86_64/netcdf.mod
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN python -m pip install -r requirements.txt
+# pin version number 3.0.3 deprecated something troute uses
+RUN python -m pip install cython==3.0.2 
+RUN ./compiler.sh no-e
+
+# add troute required modules
+RUN python -m pip install pyarrow deprecated geopandas
+
+# increase max open files soft limit
+RUN ulimit -n 10000
+ENTRYPOINT ["/opt/venv/bin/python", "-m", "nwm_routing"]
+RUN pwd
+

--- a/docker/Dockerfile.troute
+++ b/docker/Dockerfile.troute
@@ -4,7 +4,7 @@ RUN yum install -y netcdf netcdf-fortran netcdf-fortran-devel netcdf-openmpi
 
 RUN yum install -y git cmake python python-devel pip 
 # RUN git clone https://github.com/NOAA-OWP/t-route.git
-RUN git clone https://github.com/joshcu/t-route/
+RUN git clone https://github.com/TrupeshKumarPatel/t-route/
 WORKDIR "/t-route/"
 RUN git reset --hard 15bd543
 # 15bd543 <-- after LowerColorado Test fix

--- a/docker/troute.sh
+++ b/docker/troute.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+image_name="troute"
+container_yaml_dir="/config"  # The directory in the container where the YAML file will be mounted
+yaml_file_path=""
+yaml_filename=""
+parent_folder=""
+# Loop through all arguments to find the .yaml file
+for arg in "$@"; do
+    if [[ $arg == *.yaml ]]; then
+        # Get absolute path and just the filename
+        yaml_file_path="$(realpath "$arg")"
+        yaml_filename="$(basename "$arg")"
+	parent_folder="$(dirname "$yaml_file_path")"
+        break
+    fi
+done
+
+# Check if yaml_file_path was found
+if [ -z "$yaml_file_path" ]; then
+    echo "No .yaml file provided in arguments."
+    exit 1
+fi
+
+# Uncomment to print command
+#echo "docker run -v ${parent_folder}:${container_yaml_dir}/ -w ${container_yaml_dir} ${image_name} ${@/$arg/$yaml_filename}"
+
+# Mount the YAML file, set the working directory, and run the Docker container with all arguments (replacing the full YAML path with just its filename)
+docker run -v "${parent_folder}:${container_yaml_dir}/" -w "${container_yaml_dir}" ${image_name} "${@/$arg/$yaml_filename}"
+

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,13 @@ pyyaml
 
 ## Installation
 
-please see usage and testing below. Standby for docker container instructions in the near future.
+please see usage and testing below. Build your own docker image!  
+```bash
+# Clone this repo
+docker build -t troute -f docker/Dockerfile.troute
+# Use the helper script instead of python -m nwm_routing
+docker/troute.sh -V3 -f test/LowerColorado_TX/test_AnA.yaml
+```  
 
 ## Configuration
 
@@ -56,7 +62,7 @@ $ ./compiler.sh
 
 # execute a demonstration test
 $ cd test/LowerColorado_TX
-$ python3 -m nwm_routing -f test_AnA.yaml
+$ python3 -m nwm_routing -V3 -f test_AnA.yaml
 ```
 
 ## Known issues


### PR DESCRIPTION
Adds a rocky linux dockerfile that installs t-route and it's dependencies, along with a workflow to build and test the image. Also Adds a helper script so the container can be executed in the same way the python module currently is. 

## Additions

- Dockerfile.t-route - rocky linux image containing t-route and it's dependencies
- docker/t-route.sh - A helper script for running docker container
- workflows/docker.yml - On pull request to master, build the docker image, then use it to run a test. 

## Changes

- Updated documentation with docker instructions
- Updated documentation with non docker instructions

## Testing
From the root of the github repo run:
1. `docker build -t troute -f docker/Dockerfile.troute .`
2. `../troute_docker/troute.sh -V3 -f test/LowerColorado_TX/test_AnA.yaml`

## Todos

- [ ] Update dockerfile to pull from the main repo after the LowerColorado test fix gets merged
- [ ] remove extra pip installs for pyarrow deprecated geopandas, fix should be in t-route requirements.txt
- [ ] remove cython versionlock 3.0.2 command (should be in requirements.txt)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
